### PR TITLE
behave v1.2.6 (ursaverance effort)

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,3 @@
+channels:
+    - https://staging.continuum.io/prefect/fs/parse-feedstock/pr2/ae16b95
+    - https://staging.continuum.io/prefect/fs/parse_type-feedstock/pr2/eaa4d46

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,3 +1,0 @@
-channels:
-    - https://staging.continuum.io/prefect/fs/parse-feedstock/pr2/ae16b95
-    - https://staging.continuum.io/prefect/fs/parse_type-feedstock/pr2/eaa4d46

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,3 +1,2 @@
 channels:
-    - https://staging.continuum.io/prefect/fs/parse-feedstock/pr2/ae16b95
-    - https://staging.continuum.io/prefect/fs/parse_type-feedstock/pr2/eaa4d46
+    - https://staging.continuum.io/prefect/fs/behave-feedstock/pr2/7b3301d

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,3 @@
 channels:
-    - https://staging.continuum.io/prefect/fs/behave-feedstock/pr2/7b3301d
+    - https://staging.continuum.io/prefect/fs/parse-feedstock/pr2/ae16b95
+    - https://staging.continuum.io/prefect/fs/parse_type-feedstock/pr2/eaa4d46

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,6 @@ source:
 
 build:
   number: 0
-  skip: true  # [py<37]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
   entry_points:
     - behave = behave.__main__:main
@@ -26,9 +25,9 @@ requirements:
     - wheel
   run:
     - python
-    - parse >=1.6.3
-    - parse_type >=0.3.4
-    - six
+    - parse >=1.8.2
+    - parse_type >=0.4.2
+    - six >=1.11
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,5 @@
 {% set name = "behave" %}
 {% set version = "1.2.6" %}
-{% set sha256 = "b9662327aa53294c1351b0a9c369093ccec1d21026f050c3bd9b3e5cccf81a86" %}
 
 package:
   name: {{ name|lower }}
@@ -9,23 +8,24 @@ package:
 source:
   fn: {{ name }}-{{ version }}.tar.gz
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: {{ sha256 }}
+  sha256: b9662327aa53294c1351b0a9c369093ccec1d21026f050c3bd9b3e5cccf81a86
 
 build:
-  number: 1004
-  noarch: python
-  script: "{{ PYTHON }} -m pip install . --no-deps -vv"
+  number: 0
+  skip: true  # [py<37]
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
   entry_points:
     - behave = behave.__main__:main
 
 requirements:
   host:
-    - python >=3.6
+    - python
     - setuptools <58   # because of https://github.com/behave/behave/issues/955
                        # which will be released with 1.2.7
     - pip
+    - wheel
   run:
-    - python >=3.6
+    - python
     - parse >=1.6.3
     - parse_type >=0.3.4
     - six
@@ -36,12 +36,14 @@ test:
     - behave.compat
     - behave.formatter
     - behave.reporter
-
+  requires:
+    - pip
   commands:
     - behave --help
+    - pip check
 
 about:
-  home: http://github.com/behave/behave
+  home: https://github.com/behave/behave
   license: BSD-2-Clause
   license_family: BSD
   license_file: LICENSE
@@ -53,8 +55,8 @@ about:
 
     behave uses tests written in a natural language style, backed up by Python
     code.
-  doc_url: http://pythonhosted.org/behave/
-  dev_url: http://github.com/behave/behave
+  doc_url: https://behave.readthedocs.io
+  dev_url: https://github.com/behave/behave
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
[PKG-2635] behave v1.2.6

dev url: https://github.com/behave/behave/tree/v1.2.6
conda-forge: https://github.com/conda-forge/behave-feedstock
dependencies: https://github.com/behave/behave/blob/v1.2.6/setup.py

- linter
- reset build number
- remove `noarch`
- python script

**Dependency for:**
- AnacondaRecipes/allure-python-feedstock#1

**Depends on**
- AnacondaRecipes/parse_type-feedstock#2
- AnacondaRecipes/parse-feedstock#2

[PKG-2635]: https://anaconda.atlassian.net/browse/PKG-2635?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ